### PR TITLE
update amms/bonding for Scrypto v0.3.0

### DIFF
--- a/defi/amms/bonding/Cargo.toml
+++ b/defi/amms/bonding/Cargo.toml
@@ -20,7 +20,7 @@ bonding_macros = { path = "bonding_macros" }
 
 [dev-dependencies]
 radix-engine = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "v0.3.0" }
-scrypto-unit = { git = "https://github.com/devmannic/scrypto-unit", rev = "b63f0886f7e5ac9ea11a07633308cce3be4e5d45" }
+scrypto-unit = { git = "https://github.com/plymth/scrypto-unit", rev = "e259715c5b7abb6356ce2589ab1a32cdc597581f" }
 
 [profile.release]
 opt-level = 's'     # Optimize for size.

--- a/defi/amms/bonding/Cargo.toml
+++ b/defi/amms/bonding/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scrypto-bonding"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 authors = ["devmannic <82296715+devmannic@users.noreply.github.com>"]
 license = "MIT OR Apache-2.0"
@@ -13,14 +13,14 @@ A Scrypto package for creating and using bonding curves as an automated market m
 num-bigint = { version = "0.4.3", default-features = false, features = [] }
 num-rational = { version ="0.4.0", optional = true, default-features = false, features = ["num-bigint"] }
 num-traits = "0.2.14"
-sbor = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "v0.2.0" }
-scrypto = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "v0.2.0" }
-scrypto_statictypes = { git = "https://github.com/devmannic/scrypto_statictypes", tag = "v0.2.0" }
+sbor = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "v0.3.0" }
+scrypto = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "v0.3.0" }
+scrypto_statictypes = { git = "https://github.com/devmannic/scrypto_statictypes", tag = "v0.4.1" }
 bonding_macros = { path = "bonding_macros" }
 
 [dev-dependencies]
-radix-engine = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "v0.2.0" }
-scrypto-unit = { git = "https://github.com/plymth/scrypto-unit", rev = "9237a5d" }
+radix-engine = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "v0.3.0" }
+scrypto-unit = { git = "https://github.com/devmannic/scrypto-unit", rev = "b63f0886f7e5ac9ea11a07633308cce3be4e5d45" }
 
 [profile.release]
 opt-level = 's'     # Optimize for size.

--- a/defi/amms/bonding/tests/lib.rs
+++ b/defi/amms/bonding/tests/lib.rs
@@ -283,6 +283,10 @@ fn test_3_quotes() {
     let quote: Decimal = return_of_call_method(&mut receipt, "get_sell_quote_amount");
     assert_eq!(quote, 300.into());
 
+    /* this test no longer works in v0.3.0 because we can't return a BucketRef.
+     * The code is still a good example of something another blueprint might use
+     * but we just can't easily test it.  Leave here to update later
+
     // now try to get a seel quote (BucketRef) ...but can't check it easily outside of wasm
     let receipt = env.call_method(&amm.address(), "get_sell_quote", vec![
         format!("300"),
@@ -291,6 +295,8 @@ fn test_3_quotes() {
     assert!(receipt.result.is_ok());
 
     // cant introspect the BucketRef, but at least the tx succeeded
+
+    */
 
     // verify we didn't somehow actually get any RESERVE back from the BucketRef stuff
     let expected_reserve_in_account: Decimal = 1_000_000.into();

--- a/defi/amms/bonding/tests/lib.rs
+++ b/defi/amms/bonding/tests/lib.rs
@@ -1,8 +1,8 @@
-use scrypto::prelude::*;
 use radix_engine::ledger::*;
+use scrypto::prelude::*;
 use scrypto_unit::*;
 
-fn setup_fixture<'a, L: Ledger>(env: &mut TestEnv<'a, L>) -> (User, User, ResourceDef) {
+fn setup_fixture<'a, L: SubstateStore>(env: &mut TestEnv<'a, L>) -> (User, User, ResourceDef) {
     let _root = env.create_user("root");
     env.acting_as("root");
 
@@ -16,10 +16,10 @@ fn setup_fixture<'a, L: Ledger>(env: &mut TestEnv<'a, L>) -> (User, User, Resour
     // transfer some reserve tokens to them to use in testing
     let receipt = env.transfer_resource(1_000_000.into(), &reserve_def, &owner);
     println!("transfer 100k to owner: receipt: {:?}", receipt);
-    assert!(receipt.success);
+    assert!(receipt.result.is_ok());
     env.transfer_resource(1_000_000.into(), &reserve_def, &investor);
     println!("transfer 100k to investor: receipt: {:?}", receipt);
-    assert!(receipt.success);
+    assert!(receipt.result.is_ok());
 
     // use a publisher to publish the package
     let _pubisher = env.create_user("publisher");
@@ -35,7 +35,7 @@ fn setup_fixture<'a, L: Ledger>(env: &mut TestEnv<'a, L>) -> (User, User, Resour
 
 #[test]
 fn test_1() {
-    let mut ledger = InMemoryLedger::with_bootstrap();
+    let mut ledger = InMemorySubstateStore::with_bootstrap();
     let mut env = TestEnv::new(&mut ledger);
     let (owner, investor, reserve_def) = setup_fixture(&mut env);
 
@@ -52,7 +52,7 @@ fn test_1() {
 //        "".to_owned(), // hmm now do I pass 'None'
         ]);
     println!("new_default: receipt: {:?}", receipt);
-    assert!(receipt.success);
+    assert!(receipt.result.is_ok());
 
     // save off addresses
     // this is brittle checking the defs based on order...
@@ -89,7 +89,7 @@ fn test_1() {
         format!("0"),
     ]);
     println!("buy: receipt: {:?}", receipt);
-    assert!(receipt.success);
+    assert!(receipt.result.is_ok());
 
     // reserve
     let expected_reserve_in_account: Decimal = Decimal::from(1_000_000) - 300;
@@ -110,7 +110,7 @@ fn test_1() {
         format!("0"),
     ]);
     println!("sell: receipt: {:?}", receipt);
-    assert!(receipt.success);
+    assert!(receipt.result.is_ok());
     // check balances
     // reserve
     let expected_reserve_in_account: Decimal = expected_reserve_in_account + 300;
@@ -126,7 +126,7 @@ fn test_1() {
 
 #[test]
 fn test_2_basic_curve() {
-    let mut ledger = InMemoryLedger::with_bootstrap();
+    let mut ledger = InMemorySubstateStore::with_bootstrap();
     let mut env = TestEnv::new(&mut ledger);
     let (owner, investor, reserve_def) = setup_fixture(&mut env);
 
@@ -151,7 +151,7 @@ fn test_2_basic_curve() {
         format!("{}", basic_curve.address()),
         ]);
     println!("new_default: receipt: {:?}", receipt);
-    assert!(receipt.success);
+    assert!(receipt.result.is_ok());
 
     // save off addresses
     // this is brittle checking the defs based on order...
@@ -188,7 +188,7 @@ fn test_2_basic_curve() {
         format!("0"),
     ]);
     println!("buy: receipt: {:?}", receipt);
-    assert!(receipt.success);
+    assert!(receipt.result.is_ok());
 
     // check balances
     // reserve
@@ -209,7 +209,7 @@ fn test_2_basic_curve() {
         format!("0"),
     ]);
     println!("sell: receipt: {:?}", receipt);
-    assert!(receipt.success);
+    assert!(receipt.result.is_ok());
 
     // check balances
     // reserve
@@ -226,7 +226,7 @@ fn test_2_basic_curve() {
 
 #[test]
 fn test_3_quotes() {
-    let mut ledger = InMemoryLedger::with_bootstrap();
+    let mut ledger = InMemorySubstateStore::with_bootstrap();
     let mut env = TestEnv::new(&mut ledger);
     let (owner, investor, reserve_def) = setup_fixture(&mut env);
 
@@ -251,7 +251,7 @@ fn test_3_quotes() {
         format!("{}", basic_curve.address()),
         ]);
     println!("new_default: receipt: {:?}", receipt);
-    assert!(receipt.success);
+    assert!(receipt.result.is_ok());
 
     // save off addresses
     // this is brittle checking the defs based on order...
@@ -270,7 +270,7 @@ fn test_3_quotes() {
         format!("300"),
     ]);
     println!("buy_quote: receipt: {:?}", receipt);
-    assert!(receipt.success);
+    assert!(receipt.result.is_ok());
     let quote: Decimal = return_of_call_method(&mut receipt, "get_buy_quote_amount");
     assert_eq!(quote, 300.into());
 
@@ -279,7 +279,7 @@ fn test_3_quotes() {
         format!("300"),
     ]);
     println!("sell_quote_amount: receipt: {:?}", receipt);
-    assert!(receipt.success);
+    assert!(receipt.result.is_ok());
     let quote: Decimal = return_of_call_method(&mut receipt, "get_sell_quote_amount");
     assert_eq!(quote, 300.into());
 
@@ -288,7 +288,7 @@ fn test_3_quotes() {
         format!("300"),
     ]);
     println!("sell_quote: receipt: {:?}", receipt);
-    assert!(receipt.success);
+    assert!(receipt.result.is_ok());
 
     // cant introspect the BucketRef, but at least the tx succeeded
 


### PR DESCRIPTION
* [X] mutability updates and reference correct dependencies in Cargo.toml
* [X] scrypto_statictypes support for Scrypto v0.3.0 (exists as of tag v0.4.0)
* [x] scrypto-unit support for Scrypto v0.3.0

Some minor testing changes will likely also be needed here too after scrypto-unit is updated