### PR TITLE
Updated the `basic/transit` example to v0.3.0

### DIFF
--- a/basic/transit/Cargo.toml
+++ b/basic/transit/Cargo.toml
@@ -4,11 +4,11 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-sbor = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "v0.2.0" }
-scrypto = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "v0.2.0" }
+sbor = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "v0.3.0" }
+scrypto = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "v0.3.0" }
 
 [dev-dependencies]
-radix-engine = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "v0.2.0" }
+radix-engine = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "v0.3.0" }
 
 [profile.release]
 opt-level = 's'     # Optimize for size.

--- a/basic/transit/README.md
+++ b/basic/transit/README.md
@@ -72,8 +72,6 @@ resim call-method $component buy_ticket 10,$eur
 ```
 resim call-method $component ride 1,$ticket "European"
 resim call-method $component ride 1,$ticket "American"
-```
-- You should notice info messages in the console stating that is it your first ride, or you have already used the transit before.
 ## Set current epoch
 ```
 resim set-current-epoch 5
@@ -82,8 +80,6 @@ resim set-current-epoch 5
 ```
 resim call-method $component ride 1,$ticket "American"
 ```
-- You should be greeted with a welcome back message in the console, stating that this is not your first ride.
-- The transit is keeping track of your public key along with the epoch time in which you took a ride.
 ## Time to shutdown the transit and collect payments
 ```
 resim call-method $component withdraw_euros false 1,$european_badge

--- a/basic/transit/src/lib.rs
+++ b/basic/transit/src/lib.rs
@@ -89,7 +89,7 @@ blueprint! {
         }
 
         /// Accounts can buy tickets with dollars and euros
-        pub fn buy_ticket(&self, payment: Bucket) -> (Bucket, Bucket) {
+        pub fn buy_ticket(&mut self, mut payment: Bucket) -> (Bucket, Bucket) {
 
             let dollars = payment.resource_address() == self.collected_dollars.resource_address();
             let euros = payment.resource_address() == self.collected_euros.resource_address();
@@ -132,16 +132,7 @@ blueprint! {
                 payment.burn_with_auth(badge);
             });
 
-            // Keep track of riders public key/epoch
-            if self.riders.get(&Context::transaction_signers()) == None {
-                info!("Hi, this is your first ride on a transit, have fun!");
-                self.riders.insert(Context::transaction_signers(),Context::current_epoch());
-            } else if self.riders.get(&Context::transaction_signers()).unwrap() == Context::current_epoch() {
-                info!("Hi, you have already used the transit more than once during epoch: {}", Context::current_epoch())
-            } else {
-                info!("Hi, welcome back, you have not used the transit during epoch: {}", Context::current_epoch());
-                self.riders.insert(Context::transaction_signers(),Context::current_epoch());
-            }
+            info!("Welcome to the transit, have fun!")
         }
     }
 }


### PR DESCRIPTION
This pull request updates the `basic/transit` example to Scrypto v0.3.0. There is one part that I needed to remove which is where the method was checking who the transaction signers are as this is not something we can do in this version. Version 0.3.0 does not handle `GetTransactionSignersInput` anywhere. 